### PR TITLE
chore(githubactions): adding repository dispatch events for deployments

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -1,0 +1,41 @@
+name: deploy-ibm-cloud-staging (Deploy staging environments to IBM Cloud)
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install dependencies
+        run: yarn install
+      - name: Update to latest release candidate
+        run: yarn update-next
+      - name: Set env vars
+        uses: ./.github/actions/set-dotenv
+        with:
+          env-file: .env
+        env:
+          KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
+          KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
+          DDS_CALLOUT_DATA: true
+      - name: Build project
+        run: yarn build
+      - name: Export project
+        run: yarn export
+      - name: Deploying NextJS Staging to IBM Cloud
+        uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
+        with:
+          cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
+          cf-org: ibm-digital-design
+          cf-space: ibmdotcom-production
+          cf-region: us-south
+          cf-app: ibmdotcom-nextjs-staging
+          cf-manifest: manifest-staging.yml

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -1,9 +1,11 @@
-name: deploy-ibm-cloud (Deploy environments to IBM Cloud)
+name: deploy-ibm-cloud (Deploy test environments to IBM Cloud)
 
 on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types: [deploy-canary]
 
 jobs:
   deploy-test:
@@ -30,7 +32,7 @@ jobs:
         run: yarn build
       - name: Export project
         run: yarn export
-      - name: Deploying @carbon/ibmdotcom-react storybook to IBM Cloud
+      - name: Deploying NextJS Test to IBM Cloud
         uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
         with:
           cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
@@ -64,40 +66,7 @@ jobs:
         run: yarn build
       - name: Export project
         run: yarn export
-      - name: Deploying @carbon/ibmdotcom-react storybook to IBM Cloud
-        uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
-        with:
-          cloud-api-key: ${{ secrets.CLOUD_API_KEY }}
-          cf-org: ibm-digital-design
-          cf-space: ibmdotcom-production
-          cf-region: us-south
-          cf-app: ibmdotcom-nextjs-rtl
-          cf-manifest: manifest-rtl.yml
-  deploy-staging:
-    runs-on: ubuntu-16.04
-    steps:
-      - uses: actions/checkout@master
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Install dependencies
-        run: yarn install
-      - name: Update to latest release candidate
-        run: yarn update-next
-      - name: Set env vars
-        uses: ./.github/actions/set-dotenv
-        with:
-          env-file: .env
-        env:
-          KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
-          KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
-          DDS_CALLOUT_DATA: true
-      - name: Build project
-        run: yarn build
-      - name: Export project
-        run: yarn export
-      - name: Deploying @carbon/ibmdotcom-react storybook to IBM Cloud
+      - name: Deploying NextJS Test (RTL) to IBM Cloud
         uses: carbon-design-system/action-ibmcloud-cf@v1.2.0
         with:
           cloud-api-key: ${{ secrets.CLOUD_API_KEY }}


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This adds a `repository_dispatch` event for this repo to trigger
deployments when NPM canary releases are created

This is an effort to remove these jobs in our other CI builder.

### Changelog

**New**

- `repository_dispatch` event for triggering canary/test builds

**Changed**

- Moved staging builds into its own workflow so it doesn't get triggered by dispatch events
