### PR TITLE
fix(content-block-cards): import missing styles

### DIFF
--- a/styles/solutions.scss
+++ b/styles/solutions.scss
@@ -1,6 +1,7 @@
 @import "~@carbon/ibmdotcom-styles/scss/components/buttongroup/buttongroup";
 @import "~@carbon/ibmdotcom-styles/scss/components/callout-with-media/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/card-group/card-group";
+@import "~@carbon/ibmdotcom-styles/scss/components/content-block-cards/content-block-cards";
 @import "~@carbon/ibmdotcom-styles/scss/components/content-block-segmented/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/content-block-simple/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/content-group-horizontal/content-group-horizontal";


### PR DESCRIPTION
### Related Ticket(s)

#4235

### Description

Solutions page missing `content-block-cards` styles import
<img width="1425" alt="Screen Shot 2020-11-23 at 1 13 26 PM" src="https://user-images.githubusercontent.com/20210594/100016033-af52a600-2d8d-11eb-9fca-a2c42276292f.png">

### Changelog

**New**

- import styles to solutions.scss
