### PR TITLE
fix(solutions): add link to cta section button

### DIFF
--- a/pages/solutions.js
+++ b/pages/solutions.js
@@ -400,7 +400,8 @@ const Solutions = () => (
               buttons: [
                 {
                   type: "local",
-                  copy: ["Contact sales"],
+                  copy: "Contact sales",
+                  href: "https://example.com/",
                 },
               ],
             }}


### PR DESCRIPTION
### Related Ticket(s)

[NextJS Page: CTA section - Button is not operable. [Need investigation] #5195](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/5195
)
### Description

Pass url link to the cta button in `<CTASection />`

### Changelog

**New**

- pass in example link to ctasection button
