### PR TITLE
fix(callout-quote): added missing import

### DIFF
--- a/styles/solutions.scss
+++ b/styles/solutions.scss
@@ -11,6 +11,7 @@
 @import "~@carbon/ibmdotcom-styles/scss/components/leadspace-block/leadspace-block";
 @import "~@carbon/ibmdotcom-styles/scss/components/link-list/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/logo-grid/logo-grid";
+@import "~@carbon/ibmdotcom-styles/scss/components/callout-quote/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/quote/quote";
 @import "~@carbon/ibmdotcom-styles/scss/components/tableofcontents/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/video-player/video-player";


### PR DESCRIPTION
### Related Ticket(s)
https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6106

### Description
The solution page was missing the Callout Quote import, resulting in the proper background color styles not being applied.

### Changelog

**New**

- importing `CalloutQuote` styles
