### PR TITLE
fix(percy): properly trigger percy base update

### DIFF
--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types: [deploy-canary]
 
 jobs:
   percy-update:


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

I noticed that the percy base was not getting triggered, and noticed that the triggers were not configured to listen to the repository dispatch properly.

### Changelog

**Changed**

- percy-update-base.yml
