### PR TITLE
fix(images): replace breaking : character in dummy image urls

### DIFF
--- a/pages/learn.js
+++ b/pages/learn.js
@@ -158,23 +158,23 @@ const Learn = () => (
                 sources: [
                   {
                     src:
-                      "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                     breakpoint: 320,
                   },
                   {
                     src:
-                      "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                     breakpoint: 400,
                   },
                   {
                     src:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                     breakpoint: 672,
                   },
                 ],
                 alt: "Image alt text",
                 defaultSrc:
-                  "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                  "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
               },
             },
             heading: "Content Group - Simple",
@@ -243,23 +243,23 @@ const Learn = () => (
                 sources: [
                   {
                     src:
-                      "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                     breakpoint: 320,
                   },
                   {
                     src:
-                      "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                     breakpoint: 400,
                   },
                   {
                     src:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                     breakpoint: 672,
                   },
                 ],
                 alt: "Image alt text",
                 defaultSrc:
-                  "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                  "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
               },
             }}
             items={[
@@ -277,23 +277,23 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                     sources: [
                       {
                         src:
-                          "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                         breakpoint: 320,
                       },
                       {
                         src:
-                          "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                         breakpoint: 400,
                       },
                       {
                         src:
-                          "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                         breakpoint: 672,
                       },
                     ],
                     alt: "Image alt text",
                     defaultSrc:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                   },
                 },
                 copy: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum tortor. Sed id pellentesque diam. In ut quam id mauris finibus efficitur quis ut arcu. Praesent purus turpis, venenatis eget odio et, tincidunt bibendum sem. Curabitur pretium elit non blandit lobortis. Donec quis pretium odio, in dignissim sapien.
@@ -325,23 +325,23 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                 sources: [
                   {
                     src:
-                      "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                     breakpoint: 320,
                   },
                   {
                     src:
-                      "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                     breakpoint: 400,
                   },
                   {
                     src:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                     breakpoint: 672,
                   },
                 ],
                 alt: "Image alt text",
                 defaultSrc:
-                  "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                  "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
               },
             }}
             cta={{
@@ -377,23 +377,23 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                     sources: [
                       {
                         src:
-                          "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                         breakpoint: 320,
                       },
                       {
                         src:
-                          "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                         breakpoint: 400,
                       },
                       {
                         src:
-                          "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                         breakpoint: 672,
                       },
                     ],
                     alt: "Image alt text",
                     defaultSrc:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                   },
                 },
                 heading: "Lorem ipsum dolor sit amet",
@@ -426,23 +426,23 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus sed interdum to
                     sources: [
                       {
                         src:
-                          "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                         breakpoint: 320,
                       },
                       {
                         src:
-                          "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                         breakpoint: 400,
                       },
                       {
                         src:
-                          "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                          "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                         breakpoint: 672,
                       },
                     ],
                     alt: "Image alt text",
                     defaultSrc:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                   },
                 },
                 heading: "Lorem ipsum dolor sit amet",

--- a/pages/services.js
+++ b/pages/services.js
@@ -199,7 +199,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -211,7 +211,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/792x1056/ee5396/161616%26text=3:4",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -223,7 +223,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x1056/ee5396/161616%26text=1:1",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -235,7 +235,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x528/ee5396/161616%26text=2:1",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -247,7 +247,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x594/ee5396/161616%26text=16:9",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -384,7 +384,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -396,7 +396,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/792x1056/ee5396/161616%26text=3:4",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -408,7 +408,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x1056/ee5396/161616%26text=1:1",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -421,7 +421,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x528/ee5396/161616%26text=2:1",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",
@@ -433,7 +433,7 @@ const Services = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x594/ee5396/161616%26text=16:9",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Lorem",

--- a/pages/solutions.js
+++ b/pages/solutions.js
@@ -122,27 +122,27 @@ const Solutions = () => (
         image={{
           sources: [
             {
-              src: "https://dummyimage.com/320x160/ee5396/161616&text=2:1",
+              src: "https://dummyimage.com/320x160/ee5396/161616&text=2x1",
               breakpoint: "sm",
             },
             {
-              src: "https://dummyimage.com/400x200/ee5396/161616&text=2:1",
+              src: "https://dummyimage.com/400x200/ee5396/161616&text=2x1",
               breakpoint: "md",
             },
             {
-              src: "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
+              src: "https://dummyimage.com/600x600/ee5396/161616&text=1x1",
               breakpoint: 991,
             },
             {
-              src: "https://dummyimage.com/600x300/ee5396/161616&text=2:1",
+              src: "https://dummyimage.com/600x300/ee5396/161616&text=2x1",
               breakpoint: "lg",
             },
             {
-              src: "https://dummyimage.com/672x672/ee5396/161616&text=1:1",
+              src: "https://dummyimage.com/672x672/ee5396/161616&text=1x1",
               breakpoint: "xlg",
             },
           ],
-          defaultSrc: "https://dummyimage.com/600x600/ee5396/161616&text=1:1",
+          defaultSrc: "https://dummyimage.com/600x600/ee5396/161616&text=1x1",
           alt: "Image alt text",
         }}
       />
@@ -161,23 +161,23 @@ const Solutions = () => (
                 sources: [
                   {
                     src:
-                      "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                     breakpoint: 320,
                   },
                   {
                     src:
-                      "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                     breakpoint: 400,
                   },
                   {
                     src:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                     breakpoint: 672,
                   },
                 ],
                 alt: "Image alt text",
                 defaultSrc:
-                  "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                  "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
               },
             },
             cta: {
@@ -196,23 +196,23 @@ const Solutions = () => (
                 sources: [
                   {
                     src:
-                      "https://dummyimage.com/320x180/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/320x180/ee5396/161616&text=16x9",
                     breakpoint: 320,
                   },
                   {
                     src:
-                      "https://dummyimage.com/400x225/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/400x225/ee5396/161616&text=16x9",
                     breakpoint: 400,
                   },
                   {
                     src:
-                      "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                      "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
                     breakpoint: 672,
                   },
                 ],
                 alt: "Image alt text",
                 defaultSrc:
-                  "https://dummyimage.com/672x378/ee5396/161616&text=16:9",
+                  "https://dummyimage.com/672x378/ee5396/161616&text=16x9",
               },
             },
           },

--- a/pages/solutions.js
+++ b/pages/solutions.js
@@ -336,7 +336,7 @@ const Solutions = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Topic",
@@ -348,7 +348,7 @@ const Solutions = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Topic",
@@ -360,7 +360,7 @@ const Solutions = () => (
           {
             image: {
               defaultSrc:
-                "https://dummyimage.com/1056x792/ee5396/161616%26text=4:3",
+                "https://dummyimage.com/1056x792/ee5396/161616%26text=4x3",
               alt: "Image alt text",
             },
             eyebrow: "Topic",


### PR DESCRIPTION
### Related Ticket(s)

React NextJS page: All the images are not loading properly on solution page. [#6691](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/6691)

### Description

The `:` character in the dummy urls were causing the images to break, replacing `:` with `x` in the text parameter of the url fixes the issue.

**BEFORE:**
<img width="833" alt="Screen Shot 2021-08-02 at 2 13 29 PM" src="https://user-images.githubusercontent.com/54281166/127909180-39bb01be-b58d-4e60-8398-eff969376a53.png">

**AFTER:**
<img width="939" alt="Screen Shot 2021-08-02 at 2 13 08 PM" src="https://user-images.githubusercontent.com/54281166/127909187-c86161cb-ef5a-4110-baee-422cccd580dc.png">


### Changelog

**Changed**

- change the `:` to `x` in the dummy urls (ie. `https://dummyimage.com/672x378/ee5396/161616&text=16:9` to `https://dummyimage.com/672x378/ee5396/161616&text=16x9`)
