### PR TITLE
chore(housekeeping): remove callout data

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -30,7 +30,6 @@ jobs:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
-          DDS_CALLOUT_DATA: true
           SASS_PATH: node_modules:src
       - name: Build project
         run: yarn build

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -30,7 +30,6 @@ jobs:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
-          DDS_CALLOUT_DATA: true
           SASS_PATH: node_modules:src
       - name: Build project
         run: yarn build
@@ -71,7 +70,6 @@ jobs:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
-          DDS_CALLOUT_DATA: true
           SASS_PATH: node_modules:src
           ENABLE_RTL: true
       - name: Build project

--- a/.github/workflows/percy-update-base.yml
+++ b/.github/workflows/percy-update-base.yml
@@ -31,7 +31,6 @@ jobs:
           KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
           KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
-          DDS_CALLOUT_DATA: true
           SASS_PATH: node_modules:src
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       - name: Build project

--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,6 @@ module.exports = withSass({
     ALTLANG_ROOT_PATH: process.env.ALTLANG_ROOT_PATH || "/",
     KALTURA_PARTNER_ID: process.env.KALTURA_PARTNER_ID || "1773841",
     KALTURA_UICONF_ID: process.env.KALTURA_UICONF_ID || "27941801",
-    DDS_CALLOUT_DATA: process.env.DDS_CALLOUT_DATA || "false",
     ENABLE_RTL: process.env.ENABLE_RTL || "false",
   },
   sassLoaderOptions: {

--- a/pages/services.js
+++ b/pages/services.js
@@ -2,7 +2,6 @@
 import "../styles/services.scss";
 import { AccordionItem, Accordion } from "carbon-components-react";
 import {
-  CalloutData,
   CalloutWithMedia,
   ContentBlockCards,
   ContentBlockMedia,
@@ -90,12 +89,6 @@ const Services = () => (
           },
         ]}
       />
-      <CalloutData
-        data="51%"
-        copy="Lorem ipsum dolor sit amet"
-        source="Dolor sit amet"
-      />
-
       <Layout nested={true} type="2-1" border={false}>
         <div>
           <a name="content-block-media" data-title="Content Block Media" />


### PR DESCRIPTION
### Related Ticket(s)
https://app.zenhub.com/workspaces/carbon-for-ibmcom-5d449f3642eb1962336cbe52/issues/carbon-design-system/carbon-for-ibm-dotcom/6183

### Description
As part of the work deprecating the experimental components, this PR removes all uses of CalloutData and its respective feature flag in the workflows.

### Changelog

**Removed**

- `CalloutData` from the Services page
