### PR TITLE
chore(housekeeping): remove unneeded import

### DIFF
--- a/styles/services.scss
+++ b/styles/services.scss
@@ -1,4 +1,3 @@
-@import "~@carbon/ibmdotcom-styles/scss/components/callout-data/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/callout-with-media/index";
 @import "~@carbon/ibmdotcom-styles/scss/components/card-link/card-link";
 @import "~@carbon/ibmdotcom-styles/scss/components/content-block-cards/content-block-cards";


### PR DESCRIPTION
### Related Ticket(s)
https://app.zenhub.com/workspaces/carbon-for-ibmcom-5d449f3642eb1962336cbe52/issues/carbon-design-system/carbon-for-ibm-dotcom/6183

### Description
Removing unneeded style import for `CalloutData` since the styles will be removed in our library next release.

### Changelog

**Removed**

- `CalloutData` style import
