### PR TITLE
test(e2e): disable video capture by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build-export": "next build && next export",
     "lint": "eslint pages",
     "lint:styles": "stylelint '**/*.{css,scss}' --config ./packages/stylelint-config-ibmdotcom",
-    "test:e2e:local": "start-server-and-test 'http-server -c-1 out --silent' 8080 'percy exec --config tests/e2e/.percy.json -- cypress run --config-file tests/e2e/cypress.json'",
+    "test:e2e:local": "start-server-and-test 'http-server -c-1 out --silent' 8080 'percy exec --config tests/e2e/.percy.json -- cypress run --config video=false --config-file tests/e2e/cypress.json'",
+    "test:e2e:local:with-video": "start-server-and-test 'http-server -c-1 out --silent' 8080 'percy exec --config tests/e2e/.percy.json -- cypress run --config-file tests/e2e/cypress.json'",
     "update-canary": "yarn upgrade @carbon/ibmdotcom-react@canary && yarn upgrade @carbon/ibmdotcom-styles@canary",
     "update-next": "yarn upgrade @carbon/ibmdotcom-react@next && yarn upgrade @carbon/ibmdotcom-styles@next",
     "update-latest": "yarn upgrade @carbon/ibmdotcom-react@latest && yarn upgrade @carbon/ibmdotcom-styles@latest"


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

This will disable video capture in e2e testing by default. This is not necessary to have enabled in our CI runs.

### Changelog

**Changed**

- Disabled video capture in `yarn test:e2e:local`
