### PR TITLE
fix(kaltura): revert setting kaltura env vars to defaults

### DIFF
--- a/.github/workflows/deploy-ibm-cloud-staging.yml
+++ b/.github/workflows/deploy-ibm-cloud-staging.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           env-file: .env
         env:
-          KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
-          KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           SASS_PATH: node_modules:src
       - name: Build project

--- a/.github/workflows/deploy-ibm-cloud.yml
+++ b/.github/workflows/deploy-ibm-cloud.yml
@@ -32,8 +32,6 @@ jobs:
         with:
           env-file: .env
         env:
-          KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
-          KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           SASS_PATH: node_modules:src
       - name: Build project
@@ -72,8 +70,6 @@ jobs:
         with:
           env-file: .env
         env:
-          KALTURA_PARTNER_ID: ${{ secrets.KALTURA_PARTNER_ID }}
-          KALTURA_UICONF_ID: ${{ secrets.KALTURA_UICONF_ID }}
           PROFILE_HOST: ${{ secrets.PROFILE_HOST }}
           SASS_PATH: node_modules:src
           ENABLE_RTL: true


### PR DESCRIPTION
### Related Ticket(s)

No related issue

### Description

Noticed that there were a number of Kaltura calls bombing the g100 page after an e2e test was consistently failing. This might be the cause of it.

Thousands of calls to Kaltura failing:
![image](https://user-images.githubusercontent.com/1641214/142909730-e0b3d4ce-3fe5-4b5c-8238-812bead63df6.png)

e2e test failure:
![image](https://user-images.githubusercontent.com/1641214/142909794-29d4975c-3c73-4688-ac75-c5dfdef00c9a.png)

Changing the configuration to use the default IDs may fix this. These IDs are not being set in web components test currently and we are not seeing these issues there.

### Changelog

**Changed**

- Removed configuration of `KALTURA_PARTNER_ID` and `KALTURA_UICONF_ID` in canary, canary RTL, and staging deployments for IBM cloud.
