### PR TITLE
fix(percy): add additional cy.waitUntil for snapshots

### DIFF
--- a/tests/e2e/cypress/integration/example-page-a/example-page-a.e2e.js
+++ b/tests/e2e/cypress/integration/example-page-a/example-page-a.e2e.js
@@ -106,6 +106,16 @@ describe("Example page A page", () => {
   beforeEach(() => {
     cy.visit("/example-page-a.html");
     cy.viewport(1280, 780);
+
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--masthead-default__l0-nav0"]')
+        .should("be.visible")
+    );
+
+    cy.get(".bx--image__img").each(($img) => {
+      cy.waitUntil(() => cy.wrap($img).should("be.visible"));
+    });
   });
 
   it("should load the default example-page-a page", () => {

--- a/tests/e2e/cypress/integration/example-page-b/example-page-b.e2e.js
+++ b/tests/e2e/cypress/integration/example-page-b/example-page-b.e2e.js
@@ -11,6 +11,16 @@ describe("Example page B page", () => {
   it("should load the default example-page-b page", () => {
     cy.visit("/example-page-b.html");
 
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--masthead-default__l0-nav0"]')
+        .should("be.visible")
+    );
+
+    cy.get(".bx--image__img").each(($img) => {
+      cy.waitUntil(() => cy.wrap($img).should("be.visible"));
+    });
+
     // Take a snapshot for visual diffing
     cy.percySnapshot("example page b | default");
   });

--- a/tests/e2e/cypress/integration/example-page-c/example-page-c.e2e.js
+++ b/tests/e2e/cypress/integration/example-page-c/example-page-c.e2e.js
@@ -11,7 +11,15 @@ describe("Example page C page", () => {
   it("should load the default example-page-c page", () => {
     cy.visit("/example-page-c.html");
 
-    cy.wait(800);
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--masthead-default__l0-nav0"]')
+        .should("be.visible")
+    );
+
+    cy.get(".bx--image__img").each(($img) => {
+      cy.waitUntil(() => cy.wrap($img).should("be.visible"));
+    });
 
     // Take a snapshot for visual diffing
     cy.percySnapshot("example page c | default");

--- a/tests/e2e/cypress/integration/g100-theme-example/g100-theme-example.e2e.js
+++ b/tests/e2e/cypress/integration/g100-theme-example/g100-theme-example.e2e.js
@@ -11,6 +11,16 @@ describe("g100 theme example page", () => {
   it("should load the default g100-theme-example page", () => {
     cy.visit("/g100-theme-example.html");
 
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--masthead-default__l0-nav0"]')
+        .should("be.visible")
+    );
+
+    cy.get(".bx--image__img").each(($img) => {
+      cy.waitUntil(() => cy.wrap($img).should("be.visible"));
+    });
+
     // Take a snapshot for visual diffing
     cy.percySnapshot("g100-theme-example page | default");
   });

--- a/tests/e2e/cypress/integration/white-theme-example/white-theme-example.e2e.js
+++ b/tests/e2e/cypress/integration/white-theme-example/white-theme-example.e2e.js
@@ -11,6 +11,12 @@ describe("White theme example page", () => {
   it("should load the default white-theme-example page", () => {
     cy.visit("/white-theme-example.html");
 
+    cy.waitUntil(() =>
+      cy
+        .get('[data-autoid="dds--masthead-default__l0-nav0"]')
+        .should("be.visible")
+    );
+
     // Take a snapshot for visual diffing
     cy.percySnapshot("white theme example | default");
   });


### PR DESCRIPTION
### Related Ticket(s)

Refs https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues/7999

### Description

This adds additional waits for elements to load before taking snapshots.

### Changelog

**Changed**

- Add a number of `cy.waitUntil()` to tests
